### PR TITLE
During a successful signing in the session is not saved and the new one i

### DIFF
--- a/CookieJar.php
+++ b/CookieJar.php
@@ -110,9 +110,13 @@ class CookieJar
 
         $parts = parse_url($uri);
 
+        if(!isset($parts['path'])) {
+            $parts['path'] = '/';
+        }
+
         $cookies = array();
         foreach ($this->cookieJar as $cookie) {
-            if ($cookie->getDomain() && $cookie->getDomain() != substr($parts['host'], -strlen($cookie->getDomain()))) {
+            if ($cookie->getDomain() && $cookie->getDomain() != substr($parts['host'], -strlen($cookie->getDomain())) && ltrim($cookie->getDomain(), '.') != substr($parts['host'], -strlen($cookie->getDomain()))) {
                 continue;
             }
 


### PR DESCRIPTION
During a successful signing in the session is not saved and the new one is generated. The problem is that the parameter domain is set for all subdomains, for example: instead of "symfony-project.org" we indicate ".symfony-project.org".

In this case the method "allValues" returned an empty array.
