### PR TITLE
Issue 4475 of symfony/symfony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,9 @@ CHANGELOG
 2.1.0
 -----
 
+ * [BR BREAK] The Symfony\Component\HttpKernel\Client::request() method
+   now returns a Symfony\Component\BrowserKit\Response instance
+   (instead of a Symfony\Component\HttpFoundation\Response instance)
+
  * [BC BREAK] The CookieJar internals have changed to allow cookies with the
    same name on different sub-domains/sub-paths

--- a/Client.php
+++ b/Client.php
@@ -264,17 +264,17 @@ abstract class Client
             $this->response = $this->doRequest($this->request);
         }
 
-        $response = $this->filterResponse($this->response);
+        $this->response = $this->filterResponse($this->response);
 
-        $this->cookieJar->updateFromResponse($response);
+        $this->cookieJar->updateFromResponse($this->response);
 
-        $this->redirect = $response->getHeader('Location');
+        $this->redirect = $this->response->getHeader('Location');
 
         if ($this->followRedirects && $this->redirect) {
             return $this->crawler = $this->followRedirect();
         }
 
-        return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $response->getContent(), $response->getHeader('Content-Type'));
+        return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $this->response->getContent(), $this->response->getHeader('Content-Type'));
     }
 
     /**

--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\BrowserKit\Tests;
 
+use Symfony\Component\BrowserKit\Response as DomResponse;
 use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\BrowserKit\CookieJar;


### PR DESCRIPTION
In this tree, the BrowserKit Client don't return an instance of BrowserKit Response, thus breaking the interface as declared in phpDoc.
