### PR TITLE
avoid exception with Location header redirects

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -552,15 +552,15 @@ abstract class Client
     protected function getAbsoluteUri($uri)
     {
         if ($uri instanceof \Guzzle\Http\Message\Header){
-			/** @var  \Guzzle\Http\Message\Header $header */
-			$header = $uri;
-			if ($header->getName() === 'Location') {
-				$headers = $header->toArray();
-				$uri = $headers[0];
-			} else {
-				return $uri;
-			}
-		}
+            /** @var  \Guzzle\Http\Message\Header $header */
+            $header = $uri;
+            if ($header->getName() === 'Location') {
+                $headers = $header->toArray();
+                $uri = $headers[0];
+            } else {
+                return $uri;
+            }
+        }
         // already absolute?
         if (0 === strpos($uri, 'http')) {
             return $uri;


### PR DESCRIPTION
when a request (eg "/" redirects using a Location: header /de/), an exception occurs because $uri is an header-object and is used as array ($uri[0]). this patch extracts the location uri from the header and continues with the location url.
The patch does not solve redirects that expect other headers to be resend (eg auth/post)
