### PR TITLE
The Request instance converted parameters with boolean value 'false' to the empty string

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -39,7 +39,7 @@ class Request
         $this->method = $method;
 
         array_walk_recursive($parameters, static function (&$value) {
-            $value = (string) $value;
+            $value = is_bool($value) ? $value : (string) $value;
         });
 
         $this->parameters = $parameters;

--- a/Tests/RequestTest.php
+++ b/Tests/RequestTest.php
@@ -71,4 +71,19 @@ class RequestTest extends TestCase
         $request = new Request('http://www.example.com/', 'get', $parameters);
         $this->assertSame($expected, $request->getParameters());
     }
+
+    public function testFalseParameterAreNotConvertedToEmptyString()
+    {
+        $parameters = [
+            'foo' => false,
+        ];
+
+        $notExpected = [
+            'foo' => '',
+        ];
+
+        $request = new Request('http://www.example.com/', 'get', $parameters);
+        $this->assertSame($parameters, $request->getParameters());
+        $this->assertNotSame($notExpected, $request->getParameters());
+    }
 }


### PR DESCRIPTION
The issue is https://github.com/symfony/symfony/issues/48309.

